### PR TITLE
Refactor MessageProcessorBase

### DIFF
--- a/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
@@ -4,10 +4,10 @@ using System.Threading.Tasks;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public interface IMessageExtractor<TMessage>
+    public interface IMessageExtractor<TEvent, TMessage>
          where TMessage : class, new()
     {
-        Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev);
+        Task<IEnumerable<TMessage>> ExtractEventBody(TEvent ev);
     }
 
     [Obsolete("Use IMessageExtractor<TMessageType> interface instead")]

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
@@ -4,11 +4,11 @@ using System.Threading.Tasks;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public interface IMessageExtractor<TMessageType>
-         where TMessageType : class, new()
+    public interface IMessageExtractor<TMessage>
+         where TMessage : class, new()
     {
         Type ExtractorForType { get; }
-        Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev);
+        Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev);
     }
 
     [Obsolete("Use IMessageExtractor<TMessageType> interface instead")]

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/IMessageExtractor.cs
@@ -7,14 +7,12 @@ namespace MhLabs.PubSubExtensions.Consumer.Extractors
     public interface IMessageExtractor<TMessage>
          where TMessage : class, new()
     {
-        Type ExtractorForType { get; }
         Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev);
     }
 
     [Obsolete("Use IMessageExtractor<TMessageType> interface instead")]
     public interface IMessageExtractor
     {
-        Type ExtractorForType { get; }
         Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType, TMessageType>(TEventType ev) where TMessageType : class, new();
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
@@ -5,13 +5,12 @@ using System.Threading.Tasks;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class KinesisMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+    public class KinesisMessageExtractor<TMessage> : IMessageExtractor<KinesisEvent, TMessage>
           where TMessage : class, new()
     {
-        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody(KinesisEvent ev)
         {
-            var kinesisEvent = ev as KinesisEvent;
-            return await Task.FromResult(kinesisEvent.Records.Select(p => p.Kinesis.Data.DeserializeStream<TMessage>()));
+            return await Task.FromResult(ev.Records.Select(p => p.Kinesis.Data.DeserializeStream<TMessage>()));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
@@ -1,5 +1,4 @@
 using Amazon.Lambda.KinesisEvents;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,8 +8,6 @@ namespace MhLabs.PubSubExtensions.Consumer.Extractors
     public class KinesisMessageExtractor<TMessage> : IMessageExtractor<TMessage>
           where TMessage : class, new()
     {
-        public Type ExtractorForType => typeof(KinesisEvent);
-
         public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var kinesisEvent = ev as KinesisEvent;

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/KinesisMessageExtractor.cs
@@ -1,20 +1,20 @@
+using Amazon.Lambda.KinesisEvents;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Lambda.KinesisEvents;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class KinesisMessageExtractor<TMessageType> : IMessageExtractor<TMessageType>
-          where TMessageType : class, new()
+    public class KinesisMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+          where TMessage : class, new()
     {
         public Type ExtractorForType => typeof(KinesisEvent);
 
-        public async Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var kinesisEvent = ev as KinesisEvent;
-            return await Task.FromResult(kinesisEvent.Records.Select(p => p.Kinesis.Data.DeserializeStream<TMessageType>()));
+            return await Task.FromResult(kinesisEvent.Records.Select(p => p.Kinesis.Data.DeserializeStream<TMessage>()));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
@@ -1,6 +1,5 @@
 using Amazon.Lambda.SNSEvents;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,8 +9,6 @@ namespace MhLabs.PubSubExtensions.Consumer.Extractors
     public class SNSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
           where TMessage : class, new()
     {
-        public Type ExtractorForType => typeof(SNSEvent);
-
         public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var snsEvent = ev as SNSEvent;

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class SNSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+    public class SNSMessageExtractor<TMessage> : IMessageExtractor<SNSEvent, TMessage>
           where TMessage : class, new()
     {
-        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody(SNSEvent ev)
         {
-            var snsEvent = ev as SNSEvent;
-            return await Task.FromResult(snsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Sns.Message)));
+            return await Task.FromResult(ev.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Sns.Message)));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SNSMessageExtractor.cs
@@ -1,21 +1,21 @@
+using Amazon.Lambda.SNSEvents;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Lambda.SNSEvents;
-using Newtonsoft.Json;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class SNSMessageExtractor<TMessageType> : IMessageExtractor<TMessageType>
-          where TMessageType : class, new()
+    public class SNSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+          where TMessage : class, new()
     {
         public Type ExtractorForType => typeof(SNSEvent);
 
-        public async Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var snsEvent = ev as SNSEvent;
-            return await Task.FromResult(snsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessageType>(p.Sns.Message)));
+            return await Task.FromResult(snsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Sns.Message)));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
@@ -1,21 +1,21 @@
+using Amazon.Lambda.SQSEvents;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Lambda.SQSEvents;
-using Newtonsoft.Json;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class SQSMessageExtractor<TMessageType> : IMessageExtractor<TMessageType>
-          where TMessageType : class, new()
+    public class SQSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+          where TMessage : class, new()
     {
         public Type ExtractorForType => typeof(SQSEvent);
 
-        public async Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var sqsEvent = ev as SQSEvent;
-            return await Task.FromResult(sqsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessageType>(p.Body)));
+            return await Task.FromResult(sqsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Body)));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
@@ -1,6 +1,5 @@
 using Amazon.Lambda.SQSEvents;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,8 +9,6 @@ namespace MhLabs.PubSubExtensions.Consumer.Extractors
     public class SQSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
           where TMessage : class, new()
     {
-        public Type ExtractorForType => typeof(SQSEvent);
-
         public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
         {
             var sqsEvent = ev as SQSEvent;

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
@@ -6,13 +6,12 @@ using System.Threading.Tasks;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class SQSMessageExtractor<TMessage> : IMessageExtractor<TMessage>
+    public class SQSMessageExtractor<TMessage> : IMessageExtractor<SQSEvent, TMessage>
           where TMessage : class, new()
     {
-        public async Task<IEnumerable<TMessage>> ExtractEventBody<TEvent>(TEvent ev)
+        public async Task<IEnumerable<TMessage>> ExtractEventBody(SQSEvent ev)
         {
-            var sqsEvent = ev as SQSEvent;
-            return await Task.FromResult(sqsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Body)));
+            return await Task.FromResult(ev.Records.Select(p => JsonConvert.DeserializeObject<TMessage>(p.Body)));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/KinesisProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/KinesisProcessor.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.KinesisEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class KinesisProcessor<TMessage> : MessageProcessorBase<KinesisEvent, TMessage>
+        where TMessage : class, new()
+    {
+        protected KinesisProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        {
+            RegisterExtractor(new KinesisMessageExtractor<TMessage>());
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/KinesisProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/KinesisProcessor.cs
@@ -8,7 +8,8 @@ namespace MhLabs.PubSubExtensions.Consumer
     public abstract class KinesisProcessor<TMessage> : MessageProcessorBase<KinesisEvent, TMessage>
         where TMessage : class, new()
     {
-        protected KinesisProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        protected KinesisProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
+            : base(s3Client, loggerFactory)
         {
             RegisterExtractor(new KinesisMessageExtractor<TMessage>());
         }

--- a/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
@@ -45,7 +45,7 @@ namespace MhLabs.PubSubExtensions.Consumer
         {
             S3Client = s3Client ?? new AmazonS3Client(RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")));
 
-            _logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger(GetType());
+            _logger = loggerFactory?.CreateLogger(GetType()) ?? NullLogger.Instance;
         }
 
         [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]

--- a/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
@@ -1,9 +1,6 @@
 using Amazon;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.SNSEvents;
-using Amazon.Lambda.SQSEvents;
 using Amazon.S3;
-using Amazon.SQS.Model;
 using MhLabs.PubSubExtensions.Consumer.Extractors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -11,9 +8,7 @@ using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
-using static Amazon.Lambda.SNSEvents.SNSEvent;
 
 namespace MhLabs.PubSubExtensions.Consumer
 {
@@ -32,7 +27,7 @@ namespace MhLabs.PubSubExtensions.Consumer
             await Task.CompletedTask;
         }
 
-        private readonly IAmazonS3 _s3Client;
+        internal IAmazonS3 S3Client { get; }
         private readonly ILogger _logger;
 
         protected void RegisterExtractor(IMessageExtractor<TEvent, TMessage> extractor)
@@ -48,7 +43,7 @@ namespace MhLabs.PubSubExtensions.Consumer
 
         protected MessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
         {
-            _s3Client = s3Client ?? new AmazonS3Client(RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")));
+            S3Client = s3Client ?? new AmazonS3Client(RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")));
 
             _logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger(GetType());
         }
@@ -120,107 +115,12 @@ namespace MhLabs.PubSubExtensions.Consumer
             }
         }
 
-        protected virtual async Task PreparePubSubMessage(TEvent ev)
+        protected virtual Task PreparePubSubMessage(TEvent ev)
         {
-            if (typeof(TEvent) != typeof(SQSEvent) && typeof(TEvent) != typeof(SNSEvent))
-            {
-                return;
-            }
-
-            // This is ugly, but it's because SQS and SNS have different MessageAttribute references to the same data structure
-            if (ev is SQSEvent sqs)
-            {
-                await PreparePubSubMessage(sqs);
-                return;
-            }
-
-            if (ev is SNSEvent sns)
-            {
-                await PreparePubSubMessage(sns);
-                return;
-            }
+            return Task.CompletedTask;
         }
 
-        protected virtual async Task PreparePubSubMessage(SQSEvent sqs)
-        {
-            LambdaLogger.Log($"Starting to process {sqs.Records.Count} SQS records...");
-            foreach (var record in sqs.Records)
-            {
-                if (!record.MessageAttributes.ContainsKey(Constants.PubSubBucket))
-                {
-                    continue;
-                }
-
-                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
-                var bucket = record.MessageAttributes[Constants.PubSubBucket].StringValue;
-                var key = record.MessageAttributes[Constants.PubSubKey].StringValue;
-                var s3Response = await _s3Client.GetObjectAsync(bucket, key);
-                var json = await ReadStream(s3Response.ResponseStream);
-                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
-                if (snsEvent?.Message != null && snsEvent.MessageAttributes != null)
-                {
-                    record.Body = snsEvent.Message;
-
-                    LambdaLogger.Log("Adding SNS message attributes to record");
-                    foreach (var attribute in snsEvent.MessageAttributes)
-                    {
-                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
-                        {
-                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.Value });
-                        }
-                    }
-                }
-                else
-                {
-                    var sqsEvent = JsonConvert.DeserializeObject<SendMessageRequest>(json);
-                    record.Body = sqsEvent.MessageBody;
-
-                    LambdaLogger.Log("Adding SQS message attributes to record");
-                    foreach (var attribute in sqsEvent.MessageAttributes)
-                    {
-                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
-                        {
-                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.StringValue });
-                        }
-                    }
-                }
-            }
-        }
-
-        protected virtual async Task PreparePubSubMessage(SNSEvent sns)
-        {
-            LambdaLogger.Log($"Starting to process {sns.Records.Count} SNS records...");
-            foreach (var record in sns.Records)
-            {
-                if (!record.Sns.MessageAttributes.ContainsKey(Constants.PubSubBucket))
-                {
-                    continue;
-                }
-
-                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
-                var bucket = record.Sns.MessageAttributes[Constants.PubSubBucket].Value;
-                var key = record.Sns.MessageAttributes[Constants.PubSubKey].Value;
-                var s3Response = await _s3Client.GetObjectAsync(bucket, key);
-                var json = await ReadStream(s3Response.ResponseStream);
-                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
-                record.Sns.Message = snsEvent.Message;
-
-                LambdaLogger.Log("Adding SNS message attributes to record");
-                foreach (var attribute in snsEvent.MessageAttributes)
-                {
-                    if (!record.Sns.MessageAttributes.ContainsKey(attribute.Key))
-                    {
-                        record.Sns.MessageAttributes.Add(attribute.Key, attribute.Value);
-                    }
-                }
-                if (record.Sns.MessageAttributes.Any())
-                {
-                    LambdaLogger.Log($"mathem.env:sns.message_attributes:{string.Join(",", record.Sns.MessageAttributes.SelectMany(p => $"{p.Key}={p.Value?.Value?.Replace("=", "%3D")}"))}");
-                }
-            }
-        }
-
-        private async Task<string> ReadStream(Stream responseStream)
+        internal async Task<string> ReadStream(Stream responseStream)
         {
             using (var reader = new StreamReader(responseStream))
             {

--- a/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.SNSEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class SNSProcessor<TMessage> : MessageProcessorBase<SNSEvent, TMessage>
+        where TMessage : class, new()
+    {
+        protected SNSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        {
+            RegisterExtractor(new SNSMessageExtractor<TMessage>());
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
@@ -1,7 +1,12 @@
-﻿using Amazon.Lambda.SNSEvents;
+﻿using Amazon.Lambda.Core;
+using Amazon.Lambda.SNSEvents;
 using Amazon.S3;
 using MhLabs.PubSubExtensions.Consumer.Extractors;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Linq;
+using System.Threading.Tasks;
+using static Amazon.Lambda.SNSEvents.SNSEvent;
 
 namespace MhLabs.PubSubExtensions.Consumer
 {
@@ -11,6 +16,39 @@ namespace MhLabs.PubSubExtensions.Consumer
         protected SNSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
         {
             RegisterExtractor(new SNSMessageExtractor<TMessage>());
+        }
+
+        protected override async Task PreparePubSubMessage(SNSEvent sns)
+        {
+            LambdaLogger.Log($"Starting to process {sns.Records.Count} SNS records...");
+            foreach (var record in sns.Records)
+            {
+                if (!record.Sns.MessageAttributes.ContainsKey(Constants.PubSubBucket))
+                {
+                    continue;
+                }
+
+                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
+                var bucket = record.Sns.MessageAttributes[Constants.PubSubBucket].Value;
+                var key = record.Sns.MessageAttributes[Constants.PubSubKey].Value;
+                var s3Response = await S3Client.GetObjectAsync(bucket, key);
+                var json = await ReadStream(s3Response.ResponseStream);
+                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
+                record.Sns.Message = snsEvent.Message;
+
+                LambdaLogger.Log("Adding SNS message attributes to record");
+                foreach (var attribute in snsEvent.MessageAttributes)
+                {
+                    if (!record.Sns.MessageAttributes.ContainsKey(attribute.Key))
+                    {
+                        record.Sns.MessageAttributes.Add(attribute.Key, attribute.Value);
+                    }
+                }
+                if (record.Sns.MessageAttributes.Any())
+                {
+                    LambdaLogger.Log($"mathem.env:sns.message_attributes:{string.Join(",", record.Sns.MessageAttributes.SelectMany(p => $"{p.Key}={p.Value?.Value?.Replace("=", "%3D")}"))}");
+                }
+            }
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SNSProcessor.cs
@@ -13,7 +13,8 @@ namespace MhLabs.PubSubExtensions.Consumer
     public abstract class SNSProcessor<TMessage> : MessageProcessorBase<SNSEvent, TMessage>
         where TMessage : class, new()
     {
-        protected SNSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        protected SNSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
+            : base(s3Client, loggerFactory)
         {
             RegisterExtractor(new SNSMessageExtractor<TMessage>());
         }
@@ -44,7 +45,7 @@ namespace MhLabs.PubSubExtensions.Consumer
                         record.Sns.MessageAttributes.Add(attribute.Key, attribute.Value);
                     }
                 }
-                if (record.Sns.MessageAttributes.Any())
+                if (record.Sns.MessageAttributes.Count > 0)
                 {
                     LambdaLogger.Log($"mathem.env:sns.message_attributes:{string.Join(",", record.Sns.MessageAttributes.SelectMany(p => $"{p.Key}={p.Value?.Value?.Replace("=", "%3D")}"))}");
                 }

--- a/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
@@ -13,7 +13,8 @@ namespace MhLabs.PubSubExtensions.Consumer
     public abstract class SQSProcessor<TMessage> : MessageProcessorBase<SQSEvent, TMessage>
         where TMessage : class, new()
     {
-        protected SQSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        protected SQSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
+            : base(s3Client, loggerFactory)
         {
             RegisterExtractor(new SQSMessageExtractor<TMessage>());
         }

--- a/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
@@ -1,0 +1,16 @@
+﻿using Amazon.Lambda.SQSEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class SQSProcessor<TMessage> : MessageProcessorBase<SQSEvent, TMessage>
+        where TMessage : class, new()
+    {
+        protected SQSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        {
+            RegisterExtractor(new SQSMessageExtractor<TMessage>());
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSProcessor.cs
@@ -1,7 +1,12 @@
-﻿using Amazon.Lambda.SQSEvents;
+﻿using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
 using Amazon.S3;
+using Amazon.SQS.Model;
 using MhLabs.PubSubExtensions.Consumer.Extractors;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using System.Threading.Tasks;
+using static Amazon.Lambda.SNSEvents.SNSEvent;
 
 namespace MhLabs.PubSubExtensions.Consumer
 {
@@ -11,6 +16,52 @@ namespace MhLabs.PubSubExtensions.Consumer
         protected SQSProcessor(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
         {
             RegisterExtractor(new SQSMessageExtractor<TMessage>());
+        }
+
+        protected override async Task PreparePubSubMessage(SQSEvent sqs)
+        {
+            LambdaLogger.Log($"Starting to process {sqs.Records.Count} SQS records...");
+            foreach (var record in sqs.Records)
+            {
+                if (!record.MessageAttributes.ContainsKey(Constants.PubSubBucket))
+                {
+                    continue;
+                }
+
+                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
+                var bucket = record.MessageAttributes[Constants.PubSubBucket].StringValue;
+                var key = record.MessageAttributes[Constants.PubSubKey].StringValue;
+                var s3Response = await S3Client.GetObjectAsync(bucket, key);
+                var json = await ReadStream(s3Response.ResponseStream);
+                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
+                if (snsEvent?.Message != null && snsEvent.MessageAttributes != null)
+                {
+                    record.Body = snsEvent.Message;
+
+                    LambdaLogger.Log("Adding SNS message attributes to record");
+                    foreach (var attribute in snsEvent.MessageAttributes)
+                    {
+                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
+                        {
+                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.Value });
+                        }
+                    }
+                }
+                else
+                {
+                    var sqsEvent = JsonConvert.DeserializeObject<SendMessageRequest>(json);
+                    record.Body = sqsEvent.MessageBody;
+
+                    LambdaLogger.Log("Adding SQS message attributes to record");
+                    foreach (var attribute in sqsEvent.MessageAttributes)
+                    {
+                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
+                        {
+                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.StringValue });
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
+++ b/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.51</Version>
+    <Version>1.0.52</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
   </PropertyGroup> 


### PR DESCRIPTION
* `IMessageExtractor<TMessage>` -> `IMessageExtractor<TEvent, TMessage>`
* Add `SNSProcessor`, `SQSProcessor` and `KinesisProcessor`. All with the generic type argument `TMessage`
* No more pattern matching on events, i.e. `if(ev is SQSEvent sqs)`
* Various minor improvements