### PR TITLE
feat: Enable SQS partial batch failure

### DIFF
--- a/MhLabs.PubSubExtensions.sln
+++ b/MhLabs.PubSubExtensions.sln
@@ -1,11 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28010.2046
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31919.166
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MhLabs.PubSubExtensions", "MhLabs.PubSubExtensions\MhLabs.PubSubExtensions.csproj", "{04E5E7E7-EFA3-4DEF-A8A3-93C64972112C}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MhLabs.PubSubExtensions.Tests", "MhLabs.PubSubExtensions.Tests\MhLabs.PubSubExtensions.Tests.csproj", "{2C73B989-1D98-4EA8-8093-0DBAF947B75F}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{DF026519-102D-4C19-B295-63B4CDBDA3A2}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/MhLabs.PubSubExtensions/Consumer/DynamoMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/DynamoMessageProcessorBase.cs
@@ -23,6 +23,11 @@ namespace MhLabs.PubSubExtensions.Consumer
 
         protected abstract Task HandleEvent(IEnumerable<TMessageType> items, ILambdaContext context);
 
+        protected virtual Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev)
+        {
+            return Task.FromResult(default(IEnumerable<TMessageType>));
+        }
+
         protected virtual async Task HandleRawEvent(DynamoDBEvent items, ILambdaContext context)
         {
             await Task.CompletedTask;
@@ -39,7 +44,9 @@ namespace MhLabs.PubSubExtensions.Consumer
             try
             {
                 await PreparePubSubMessage(ev);
-                var rawData = await _messageExtractor.ExtractEventBody(ev);
+                var rawData = _messageExtractor == null ? 
+                    await ExtractEventBody(ev) : 
+                    await _messageExtractor.ExtractEventBody(ev);
 
                 await HandleEvent(rawData, context);
                 await HandleRawEvent(ev, context);

--- a/MhLabs.PubSubExtensions/Consumer/DynamoMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/DynamoMessageProcessorBase.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.DynamoDBEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class DynamoMessageProcessorBase<TMessageType> : MessageProcessorBase<DynamoDBEvent>
+        where TMessageType : class, new()
+    {
+        private IMessageExtractor<TMessageType> _messageExtractor;
+
+        protected DynamoMessageProcessorBase(
+            IAmazonS3 s3Client = null, 
+            ILoggerFactory loggerFactory = null) : 
+            base(s3Client, loggerFactory)
+        {
+        }
+
+        protected abstract Task HandleEvent(IEnumerable<TMessageType> items, ILambdaContext context);
+
+        protected virtual async Task HandleRawEvent(DynamoDBEvent items, ILambdaContext context)
+        {
+            await Task.CompletedTask;
+        }
+
+        protected void RegisterExtractor(IMessageExtractor<TMessageType> extractor)
+        {
+            _messageExtractor = extractor;
+        }
+
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public async Task Process(DynamoDBEvent ev, ILambdaContext context)
+        {
+            try
+            {
+                await PreparePubSubMessage(ev);
+                var rawData = await _messageExtractor.ExtractEventBody(ev);
+
+                await HandleEvent(rawData, context);
+                await HandleRawEvent(ev, context);
+            }
+            catch (Exception exception)
+            {
+                LogError(ev, exception, context);
+
+                var result = await HandleError(ev, context, exception);
+                if (result == HandleErrorResult.Throw)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
+++ b/MhLabs.PubSubExtensions/Consumer/Extractors/SQSMessageExtractor.cs
@@ -3,19 +3,24 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon.Lambda.SQSEvents;
+using MhLabs.PubSubExtensions.Model;
 using Newtonsoft.Json;
 
 namespace MhLabs.PubSubExtensions.Consumer.Extractors
 {
-    public class SQSMessageExtractor<TMessageType> : IMessageExtractor<TMessageType>
+    public class SQSMessageExtractor<TMessageType> : IMessageExtractor<SQSMessageEnvelope<TMessageType>>
           where TMessageType : class, new()
     {
         public Type ExtractorForType => typeof(SQSEvent);
 
-        public async Task<IEnumerable<TMessageType>> ExtractEventBody<TEventType>(TEventType ev)
+        public async Task<IEnumerable<SQSMessageEnvelope<TMessageType>>> ExtractEventBody<TEventType>(TEventType ev)
         {
             var sqsEvent = ev as SQSEvent;
-            return await Task.FromResult(sqsEvent.Records.Select(p => JsonConvert.DeserializeObject<TMessageType>(p.Body)));
+            return await Task.FromResult(sqsEvent.Records.Select(p => new SQSMessageEnvelope<TMessageType>
+            {
+                Message = JsonConvert.DeserializeObject<TMessageType>(p.Body),
+                MessageId = p.MessageId
+            }));
         }
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/KinesisMessageMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/KinesisMessageMessageProcessorBase.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.KinesisEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class KinesisMessageMessageProcessorBase<TMessageType> : MessageProcessorBase<KinesisEvent> where TMessageType : class, new()
+    {
+        private IMessageExtractor<TMessageType> _messageExtractor;
+
+        protected KinesisMessageMessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        {
+            _messageExtractor = new KinesisMessageExtractor<TMessageType>();
+        }
+
+        protected abstract Task HandleEvent(IEnumerable<TMessageType> items, ILambdaContext context);
+
+        protected virtual async Task HandleRawEvent(KinesisEvent items, ILambdaContext context)
+        {
+            await Task.CompletedTask;
+        }
+
+        protected void RegisterExtractor(IMessageExtractor<TMessageType> extractor)
+        {
+            _messageExtractor = extractor;
+        }
+
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public async Task Process(KinesisEvent ev, ILambdaContext context)
+        {
+            try
+            {
+                await PreparePubSubMessage(ev);
+                var rawData = await _messageExtractor.ExtractEventBody(ev);
+
+                await HandleEvent(rawData, context);
+                await HandleRawEvent(ev, context);
+            }
+            catch (Exception exception)
+            {
+                LogError(ev, exception, context);
+
+                var result = await HandleError(ev, context, exception);
+                if (result == HandleErrorResult.Throw)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
@@ -54,7 +54,7 @@ namespace MhLabs.PubSubExtensions.Consumer
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Exception during LogError: {ex}");
+                context.Logger.Log($"Exception during LogError: {ex}");
             }
         }
 

--- a/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/MessageProcessorBase.cs
@@ -1,248 +1,172 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using Amazon;
 using Amazon.Lambda.Core;
-using Amazon.Lambda.KinesisEvents;
 using Amazon.Lambda.SNSEvents;
 using Amazon.Lambda.SQSEvents;
 using Amazon.S3;
 using Amazon.SQS.Model;
-using MhLabs.PubSubExtensions.Consumer.Extractors;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
-using static Amazon.Lambda.SNSEvents.SNSEvent;
 
-namespace MhLabs.PubSubExtensions.Consumer
+namespace MhLabs.PubSubExtensions.Consumer;
+
+public abstract class MessageProcessorBase<TEventType>
 {
-    public abstract class MessageProcessorBase<TEventType, TMessageType> where TMessageType : class, new()
+    private readonly IAmazonS3 _s3Client;
+    private readonly ILogger _logger;
+
+    protected MessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
     {
-        private IMessageExtractor<TMessageType> _messageExtractor;
+        _s3Client = s3Client ?? new AmazonS3Client(RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")));
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        private IMessageExtractor _deprecatedExtractor;
-#pragma warning restore CS0618 // Type or member is obsolete
+       _logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger(GetType());
+    }
 
-        protected abstract Task HandleEvent(IEnumerable<TMessageType> items, ILambdaContext context);
+    protected virtual Task<HandleErrorResult> HandleError(TEventType ev, ILambdaContext context, Exception exception)
+    {
+        return Task.FromResult(HandleErrorResult.Throw);
+    }
 
-        protected virtual async Task HandleRawEvent(TEventType items, ILambdaContext context)
+    protected void LogError(TEventType ev, Exception exception, ILambdaContext context)
+    {
+        try
         {
-            await Task.CompletedTask;
-        }
+            var payload = JsonConvert.SerializeObject(ev);
+            var eventType = ev?.GetType();
 
-        private readonly IAmazonS3 _s3Client;
-        private readonly ILogger _logger;
-
-        protected void RegisterExtractor(IMessageExtractor<TMessageType> extractor)
-        {
-            _messageExtractor = extractor;
-        }
-
-        [Obsolete("Use IMessageExtractor<TMessageType> interface instead")]
-        protected void RegisterExtractor(IMessageExtractor extractor)
-        {
-            _deprecatedExtractor = extractor;
-        }
-
-        protected MessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null)
-        {
-            _s3Client = s3Client ?? new AmazonS3Client(RegionEndpoint.GetBySystemName(Environment.GetEnvironmentVariable("AWS_REGION")));
-
-            if (typeof(TEventType) == typeof(SQSEvent))
+            if (_logger == NullLogger.Instance)
             {
-                _messageExtractor = new SQSMessageExtractor<TMessageType>();
+                context.Logger.Log($"Error when processing message type: {eventType}. Raw message: {payload}");
             }
-            else if (typeof(TEventType) == typeof(SNSEvent))
+            else
             {
-                _messageExtractor = new SNSMessageExtractor<TMessageType>();
-            }
-            else if (typeof(TEventType) == typeof(KinesisEvent))
-            {
-                _messageExtractor = new KinesisMessageExtractor<TMessageType>();
-            }
-
-            _deprecatedExtractor = default;
-
-            _logger = loggerFactory == null ? NullLogger.Instance : loggerFactory.CreateLogger(GetType());
-        }
-
-        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
-        public async Task Process(TEventType ev, ILambdaContext context)
-        {
-            try
-            {
-                await PreparePubSubMessage(ev);
-
-                IEnumerable<TMessageType> rawData;
-                if (_deprecatedExtractor != default)
-                {
-                    rawData = await _deprecatedExtractor.ExtractEventBody<TEventType, TMessageType>(ev);
-                }
-                else
-                {
-                    rawData = await _messageExtractor.ExtractEventBody(ev);
-                }
-
-                await HandleEvent(rawData, context);
-                await HandleRawEvent(ev, context);
-            }
-            catch (Exception exception)
-            {
-                LogError(ev, exception, context);
-
-                var result = await HandleError(ev, context, exception);
-                if (result == HandleErrorResult.Throw)
-                {
-                    throw;
-                }
+                _logger.LogError(exception,
+                    "Error when processing message type: {TEventType}. Raw message: {TEvent}",
+                    eventType, payload);
             }
         }
-
-        protected virtual Task<HandleErrorResult> HandleError(TEventType ev, ILambdaContext context, Exception exception)
+        catch (Exception ex)
         {
-            return Task.FromResult(HandleErrorResult.Throw);
+            Console.WriteLine($"Exception during LogError: {ex}");
+        }
+    }
+
+    protected virtual async Task PreparePubSubMessage(TEventType ev)
+    {
+        if (typeof(TEventType) != typeof(SQSEvent) && typeof(TEventType) != typeof(SNSEvent))
+        {
+            return;
         }
 
-        protected enum HandleErrorResult
+        // This is ugly, but it's because SQS and SNS have different MessageAttribute references to the same data structure
+        if (ev is SQSEvent sqs)
         {
-            Throw,
-            ErrorHandledByConsumer
+            await PreparePubSubMessage(sqs);
+            return;
         }
 
-        private void LogError(TEventType ev, Exception exception, ILambdaContext context)
+        if (ev is SNSEvent sns)
         {
-            try
-            {
-                var payload = JsonConvert.SerializeObject(ev);
-                var eventType = ev?.GetType();
-
-                if (_logger == NullLogger.Instance)
-                {
-                    context.Logger.Log($"Error when processing message type: {eventType}. Raw message: {payload}");
-                }
-                else
-                {
-                    _logger.LogError(exception,
-                        "Error when processing message type: {TEventType}. Raw message: {TEvent}",
-                        eventType, payload);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Exception during LogError: {ex}");
-            }
+            await PreparePubSubMessage(sns);
+            return;
         }
+    }
 
-        protected virtual async Task PreparePubSubMessage(TEventType ev)
+    protected virtual async Task PreparePubSubMessage(SQSEvent sqs)
+    {
+        LambdaLogger.Log($"Starting to process {sqs.Records.Count} SQS records...");
+        foreach (var record in sqs.Records)
         {
-            if (typeof(TEventType) != typeof(SQSEvent) && typeof(TEventType) != typeof(SNSEvent))
+            if (!record.MessageAttributes.ContainsKey(Constants.PubSubBucket))
             {
-                return;
+                continue;
             }
 
-            // This is ugly, but it's because SQS and SNS have different MessageAttribute references to the same data structure
-            if (ev is SQSEvent sqs)
+            LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
+            var bucket = record.MessageAttributes[Constants.PubSubBucket].StringValue;
+            var key = record.MessageAttributes[Constants.PubSubKey].StringValue;
+            var s3Response = await _s3Client.GetObjectAsync(bucket, key);
+            var json = await ReadStream(s3Response.ResponseStream);
+            var snsEvent = JsonConvert.DeserializeObject<SNSEvent.SNSMessage>(json);
+            if (snsEvent?.Message != null && snsEvent.MessageAttributes != null)
             {
-                await PreparePubSubMessage(sqs);
-                return;
-            }
-
-            if (ev is SNSEvent sns)
-            {
-                await PreparePubSubMessage(sns);
-                return;
-            }
-        }
-
-        protected virtual async Task PreparePubSubMessage(SQSEvent sqs)
-        {
-            LambdaLogger.Log($"Starting to process {sqs.Records.Count} SQS records...");
-            foreach (var record in sqs.Records)
-            {
-                if (!record.MessageAttributes.ContainsKey(Constants.PubSubBucket))
-                {
-                    continue;
-                }
-
-                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
-                var bucket = record.MessageAttributes[Constants.PubSubBucket].StringValue;
-                var key = record.MessageAttributes[Constants.PubSubKey].StringValue;
-                var s3Response = await _s3Client.GetObjectAsync(bucket, key);
-                var json = await ReadStream(s3Response.ResponseStream);
-                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
-                if (snsEvent?.Message != null && snsEvent.MessageAttributes != null)
-                {
-                    record.Body = snsEvent.Message;
-
-                    LambdaLogger.Log("Adding SNS message attributes to record");
-                    foreach (var attribute in snsEvent.MessageAttributes)
-                    {
-                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
-                        {
-                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.Value });
-                        }
-                    }
-                }
-                else
-                {
-                    var sqsEvent = JsonConvert.DeserializeObject<SendMessageRequest>(json);
-                    record.Body = sqsEvent.MessageBody;
-
-                    LambdaLogger.Log("Adding SQS message attributes to record");
-                    foreach (var attribute in sqsEvent.MessageAttributes)
-                    {
-                        if (!record.MessageAttributes.ContainsKey(attribute.Key))
-                        {
-                            record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.StringValue });
-                        }
-                    }
-                }
-            }
-        }
-
-        protected virtual async Task PreparePubSubMessage(SNSEvent sns)
-        {
-            LambdaLogger.Log($"Starting to process {sns.Records.Count} SNS records...");
-            foreach (var record in sns.Records)
-            {
-                if (!record.Sns.MessageAttributes.ContainsKey(Constants.PubSubBucket))
-                {
-                    continue;
-                }
-
-                LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
-                var bucket = record.Sns.MessageAttributes[Constants.PubSubBucket].Value;
-                var key = record.Sns.MessageAttributes[Constants.PubSubKey].Value;
-                var s3Response = await _s3Client.GetObjectAsync(bucket, key);
-                var json = await ReadStream(s3Response.ResponseStream);
-                var snsEvent = JsonConvert.DeserializeObject<SNSMessage>(json);
-                record.Sns.Message = snsEvent.Message;
+                record.Body = snsEvent.Message;
 
                 LambdaLogger.Log("Adding SNS message attributes to record");
                 foreach (var attribute in snsEvent.MessageAttributes)
                 {
-                    if (!record.Sns.MessageAttributes.ContainsKey(attribute.Key))
+                    if (!record.MessageAttributes.ContainsKey(attribute.Key))
                     {
-                        record.Sns.MessageAttributes.Add(attribute.Key, attribute.Value);
+                        record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.Value });
                     }
                 }
-                if (record.Sns.MessageAttributes.Any())
-                {
-                    LambdaLogger.Log($"mathem.env:sns.message_attributes:{string.Join(",", record.Sns.MessageAttributes.SelectMany(p => $"{p.Key}={p.Value?.Value?.Replace("=", "%3D")}"))}");
-                }
-
             }
-        }
-
-        private async Task<string> ReadStream(Stream responseStream)
-        {
-            using(var reader = new StreamReader(responseStream))
+            else
             {
-                return await reader.ReadToEndAsync();
+                var sqsEvent = JsonConvert.DeserializeObject<SendMessageRequest>(json);
+                record.Body = sqsEvent.MessageBody;
+
+                LambdaLogger.Log("Adding SQS message attributes to record");
+                foreach (var attribute in sqsEvent.MessageAttributes)
+                {
+                    if (!record.MessageAttributes.ContainsKey(attribute.Key))
+                    {
+                        record.MessageAttributes.Add(attribute.Key, new SQSEvent.MessageAttribute { DataType = "String", StringValue = attribute.Value.StringValue });
+                    }
+                }
             }
         }
+    }
+
+    protected virtual async Task PreparePubSubMessage(SNSEvent sns)
+    {
+        LambdaLogger.Log($"Starting to process {sns.Records.Count} SNS records...");
+        foreach (var record in sns.Records)
+        {
+            if (!record.Sns.MessageAttributes.ContainsKey(Constants.PubSubBucket))
+            {
+                continue;
+            }
+
+            LambdaLogger.Log($"The records message attributes contains key {Constants.PubSubBucket}");
+            var bucket = record.Sns.MessageAttributes[Constants.PubSubBucket].Value;
+            var key = record.Sns.MessageAttributes[Constants.PubSubKey].Value;
+            var s3Response = await _s3Client.GetObjectAsync(bucket, key);
+            var json = await ReadStream(s3Response.ResponseStream);
+            var snsEvent = JsonConvert.DeserializeObject<SNSEvent.SNSMessage>(json);
+            record.Sns.Message = snsEvent.Message;
+
+            LambdaLogger.Log("Adding SNS message attributes to record");
+            foreach (var attribute in snsEvent.MessageAttributes)
+            {
+                if (!record.Sns.MessageAttributes.ContainsKey(attribute.Key))
+                {
+                    record.Sns.MessageAttributes.Add(attribute.Key, attribute.Value);
+                }
+            }
+            if (record.Sns.MessageAttributes.Any())
+            {
+                LambdaLogger.Log($"mathem.env:sns.message_attributes:{string.Join(",", record.Sns.MessageAttributes.SelectMany(p => $"{p.Key}={p.Value?.Value?.Replace("=", "%3D")}"))}");
+            }
+
+        }
+    }
+
+    private async Task<string> ReadStream(Stream responseStream)
+    {
+        using(var reader = new StreamReader(responseStream))
+        {
+            return await reader.ReadToEndAsync();
+        }
+    }
+
+    protected enum HandleErrorResult
+    {
+        Throw,
+        ErrorHandledByConsumer
     }
 }

--- a/MhLabs.PubSubExtensions/Consumer/SNSMessageMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SNSMessageMessageProcessorBase.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SNSEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer
+{
+    public abstract class SNSMessageMessageProcessorBase<TMessageType> : MessageProcessorBase<SNSEvent> where TMessageType : class, new()
+    {
+        private IMessageExtractor<TMessageType> _messageExtractor;
+
+        protected SNSMessageMessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+        {
+            _messageExtractor = new SNSMessageExtractor<TMessageType>();
+        }
+
+        protected abstract Task HandleEvent(IEnumerable<TMessageType> items, ILambdaContext context);
+
+        protected virtual async Task HandleRawEvent(SNSEvent items, ILambdaContext context)
+        {
+            await Task.CompletedTask;
+        }
+
+        protected void RegisterExtractor(IMessageExtractor<TMessageType> extractor)
+        {
+            _messageExtractor = extractor;
+        }
+
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public async Task Process(SNSEvent ev, ILambdaContext context)
+        {
+            try
+            {
+                await PreparePubSubMessage(ev);
+                var rawData = await _messageExtractor.ExtractEventBody(ev);
+
+                await HandleEvent(rawData, context);
+                await HandleRawEvent(ev, context);
+            }
+            catch (Exception exception)
+            {
+                LogError(ev, exception, context);
+
+                var result = await HandleError(ev, context, exception);
+                if (result == HandleErrorResult.Throw)
+                {
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
@@ -54,7 +54,7 @@ namespace MhLabs.PubSubExtensions.Consumer
                 var rawData = await _messageExtractor.ExtractEventBody(ev);
 
                 var response = await HandleEvent(rawData, context);
-                var responseFromRaw = await HandleEvent(rawData, context);
+                var responseFromRaw = await HandleRawEvent(ev, context);
 
                 var failures = new List<BatchItemFailure>();
                 failures.AddRange(response.BatchItemFailures);

--- a/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Amazon.Lambda.Core;
+using Amazon.Lambda.SQSEvents;
+using Amazon.S3;
+using MhLabs.PubSubExtensions.Consumer.Extractors;
+using MhLabs.PubSubExtensions.Model;
+using Microsoft.Extensions.Logging;
+
+namespace MhLabs.PubSubExtensions.Consumer;
+
+public abstract class SQSMessageProcessorBase<TMessageType> : MessageProcessorBase<SQSEvent> where TMessageType : class, new()
+{
+    private IMessageExtractor<SQSMessageEnvelope<TMessageType>> _messageExtractor;
+
+    protected SQSMessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+    {
+        _messageExtractor = new SQSMessageExtractor<TMessageType>();
+    }
+
+    protected abstract Task<SQSResponse> HandleEvent(IEnumerable<SQSMessageEnvelope<TMessageType>> items, ILambdaContext context);
+
+    protected virtual Task<SQSResponse> HandleRawEvent(SQSEvent items, ILambdaContext context)
+    {
+        return Task.FromResult(new SQSResponse());
+    }
+
+    protected void RegisterExtractor(IMessageExtractor<SQSMessageEnvelope<TMessageType>> extractor)
+    {
+        _messageExtractor = extractor;
+    }
+
+    [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+    public async Task<SQSResponse> Process(SQSEvent ev, ILambdaContext context)
+    {
+        try
+        {
+            await PreparePubSubMessage(ev);
+
+            var rawData = await _messageExtractor.ExtractEventBody(ev);
+
+            var response =  await HandleEvent(rawData, context);
+            var responseFromRaw =  await HandleEvent(rawData, context);
+
+            var failures = new List<BatchItemFailure>();
+            failures.AddRange(response.BatchItemFailures);
+            failures.AddRange(responseFromRaw.BatchItemFailures);
+
+            return new SQSResponse
+            {
+                BatchItemFailures = failures
+            };
+        }
+        catch (Exception exception)
+        {
+            LogError(ev, exception, context);
+
+            var result = await HandleError(ev, context, exception);
+            if (result == HandleErrorResult.Throw)
+            {
+                throw;
+            }
+
+            return new SQSResponse
+            {
+                BatchItemFailures = ev.Records.Select(x => new BatchItemFailure { ItemIdentifier = x.MessageId }).ToList()
+            };
+        }
+    }
+}

--- a/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
+++ b/MhLabs.PubSubExtensions/Consumer/SQSMessageProcessorBase.cs
@@ -9,64 +9,78 @@ using MhLabs.PubSubExtensions.Consumer.Extractors;
 using MhLabs.PubSubExtensions.Model;
 using Microsoft.Extensions.Logging;
 
-namespace MhLabs.PubSubExtensions.Consumer;
-
-public abstract class SQSMessageProcessorBase<TMessageType> : MessageProcessorBase<SQSEvent> where TMessageType : class, new()
+namespace MhLabs.PubSubExtensions.Consumer
 {
-    private IMessageExtractor<SQSMessageEnvelope<TMessageType>> _messageExtractor;
 
-    protected SQSMessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(s3Client, loggerFactory)
+    /// <summary>
+    /// This class receives SQS events and invokes the HandleEvent method with deserialised objects
+    /// of the type TMessageType. If the message contained a large message it will automatically
+    /// download it from S3. If you configure the lambda to handle partial batch failure you can
+    /// return the failed message ids on the SQS response. Make sure to also override HandleError
+    /// and set the return value to ErrorHandledByConsumer.
+    /// </summary>
+    /// <typeparam name="TMessageType">The type of the message in your SQS message</typeparam>
+    public abstract class SQSMessageProcessorBase<TMessageType> : MessageProcessorBase<SQSEvent>
+        where TMessageType : class, new()
     {
-        _messageExtractor = new SQSMessageExtractor<TMessageType>();
-    }
+        private IMessageExtractor<SQSMessageEnvelope<TMessageType>> _messageExtractor;
 
-    protected abstract Task<SQSResponse> HandleEvent(IEnumerable<SQSMessageEnvelope<TMessageType>> items, ILambdaContext context);
-
-    protected virtual Task<SQSResponse> HandleRawEvent(SQSEvent items, ILambdaContext context)
-    {
-        return Task.FromResult(new SQSResponse());
-    }
-
-    protected void RegisterExtractor(IMessageExtractor<SQSMessageEnvelope<TMessageType>> extractor)
-    {
-        _messageExtractor = extractor;
-    }
-
-    [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
-    public async Task<SQSResponse> Process(SQSEvent ev, ILambdaContext context)
-    {
-        try
+        protected SQSMessageProcessorBase(IAmazonS3 s3Client = null, ILoggerFactory loggerFactory = null) : base(
+            s3Client, loggerFactory)
         {
-            await PreparePubSubMessage(ev);
-
-            var rawData = await _messageExtractor.ExtractEventBody(ev);
-
-            var response =  await HandleEvent(rawData, context);
-            var responseFromRaw =  await HandleEvent(rawData, context);
-
-            var failures = new List<BatchItemFailure>();
-            failures.AddRange(response.BatchItemFailures);
-            failures.AddRange(responseFromRaw.BatchItemFailures);
-
-            return new SQSResponse
-            {
-                BatchItemFailures = failures
-            };
+            _messageExtractor = new SQSMessageExtractor<TMessageType>();
         }
-        catch (Exception exception)
+
+        protected abstract Task<SQSResponse> HandleEvent(IEnumerable<SQSMessageEnvelope<TMessageType>> items,
+            ILambdaContext context);
+
+        protected virtual Task<SQSResponse> HandleRawEvent(SQSEvent items, ILambdaContext context)
         {
-            LogError(ev, exception, context);
+            return Task.FromResult(new SQSResponse());
+        }
 
-            var result = await HandleError(ev, context, exception);
-            if (result == HandleErrorResult.Throw)
+        protected void RegisterExtractor(IMessageExtractor<SQSMessageEnvelope<TMessageType>> extractor)
+        {
+            _messageExtractor = extractor;
+        }
+
+        [LambdaSerializer(typeof(Amazon.Lambda.Serialization.Json.JsonSerializer))]
+        public async Task<SQSResponse> Process(SQSEvent ev, ILambdaContext context)
+        {
+            try
             {
-                throw;
+                await PreparePubSubMessage(ev);
+
+                var rawData = await _messageExtractor.ExtractEventBody(ev);
+
+                var response = await HandleEvent(rawData, context);
+                var responseFromRaw = await HandleEvent(rawData, context);
+
+                var failures = new List<BatchItemFailure>();
+                failures.AddRange(response.BatchItemFailures);
+                failures.AddRange(responseFromRaw.BatchItemFailures);
+
+                return new SQSResponse
+                {
+                    BatchItemFailures = failures
+                };
             }
-
-            return new SQSResponse
+            catch (Exception exception)
             {
-                BatchItemFailures = ev.Records.Select(x => new BatchItemFailure { ItemIdentifier = x.MessageId }).ToList()
-            };
+                LogError(ev, exception, context);
+
+                var result = await HandleError(ev, context, exception);
+                if (result == HandleErrorResult.Throw)
+                {
+                    throw;
+                }
+
+                return new SQSResponse
+                {
+                    BatchItemFailures = ev.Records.Select(x => new BatchItemFailure {ItemIdentifier = x.MessageId})
+                        .ToList()
+                };
+            }
         }
     }
 }

--- a/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
+++ b/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.Core" Version="2.0.0" />
+    <PackageReference Include="Amazon.Lambda.DynamoDBEvents" Version="2.1.0" />
     <PackageReference Include="Amazon.Lambda.KinesisEvents" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.SNSEvents" Version="2.0.0" />
     <PackageReference Include="Amazon.Lambda.SQSEvents" Version="2.0.0" />

--- a/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
+++ b/MhLabs.PubSubExtensions/MhLabs.PubSubExtensions.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>3.0.0</Version>
+    <Version>4.0.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/MhLabs.PubSubExtensions/Model/SQSMessageEnvelope.cs
+++ b/MhLabs.PubSubExtensions/Model/SQSMessageEnvelope.cs
@@ -1,0 +1,8 @@
+﻿namespace MhLabs.PubSubExtensions.Model
+{
+    public class SQSMessageEnvelope<T> where T : class, new()
+    {
+        public string MessageId { get; set; }
+        public T Message { get; set; }
+    }
+}

--- a/MhLabs.PubSubExtensions/Model/SQSResponse.cs
+++ b/MhLabs.PubSubExtensions/Model/SQSResponse.cs
@@ -6,7 +6,7 @@ namespace MhLabs.PubSubExtensions.Model
     public class SQSResponse
     {
         [JsonProperty(PropertyName = "batchItemFailures")]
-        public List<BatchItemFailure> BatchItemFailures { get; set; }
+        public List<BatchItemFailure> BatchItemFailures { get; set; } = new List<BatchItemFailure>();
     }
 
     public class BatchItemFailure

--- a/MhLabs.PubSubExtensions/Model/SQSResponse.cs
+++ b/MhLabs.PubSubExtensions/Model/SQSResponse.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace MhLabs.PubSubExtensions.Model
+{
+    public class SQSResponse
+    {
+        [JsonProperty(PropertyName = "batchItemFailures")]
+        public List<BatchItemFailure> BatchItemFailures { get; set; }
+    }
+
+    public class BatchItemFailure
+    {
+        [JsonProperty(PropertyName = "itemIdentifier")]
+        public string ItemIdentifier { get; set; }
+    }
+}


### PR DESCRIPTION
Split MessageProcessorBase into multiple specific classes for each event type. This allows them to have different responses which is required for SQS partial failures. Also removed deprecated functionality. 

Upgrade path is to change any classes inheriting from MessageProcessorBase to instead inherit from SQS/SNS/Kinesis-MessageProcessorBase and for SQS implement the updated interface. Example of SQS implementations below

**Handler that doesn't care about partial batch failure**
```
public class SQSConsumer : SQSMessageProcessorBase<OrderEvent>
{
    protected override async Task<SQSResponse> HandleEvent(IEnumerable<SQSMessageEnvelope<OrderEvent>> items, ILambdaContext context)
    {
        foreach (var orderEvent in items)
        {
            // Do something with event
        }
        // Have to return to match interface
        return default;
}
```

**Handler that does care about partial batch failure**

```
public class SQSConsumer : SQSMessageProcessorBase<OrderEvent>
{
    protected override Task<HandleErrorResult> HandleError(SQSEvent ev, ILambdaContext context, Exception exception)
    {
        return Task.FromResult(HandleErrorResult.ErrorHandledByConsumer);
    }

    protected override async Task<SQSResponse> HandleEvent(IEnumerable<SQSMessageEnvelope<OrderEvent>> items, ILambdaContext context)
    {
        var failures = new List<BatchItemFailure>();
        foreach (var orderEvent in items)
        {
            try
            {
                // Do something with event
            }
            catch (System.Exception e)
            {
                failures.Add(new BatchItemFailure
                {
                    ItemIdentifier = orderEvent.MessageId
                });
            }
        }
        return new SQSResponse
        {
            BatchItemFailures = failures
        };
    }
}
```